### PR TITLE
Fix volume path in quickstart documentation

### DIFF
--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -40,7 +40,7 @@ docker run --name mantrae \
    -e SECRET=your-generated-secret \
    -e ADMIN_PASSWORD=your-admin-password \
    -p 3000:3000 \
-   -v mantrae-data:/app/data \
+   -v ./mantrae:/data \
    ghcr.io/mizuchilabs/mantrae:latest
 ```
 
@@ -59,7 +59,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ./mantrae:/app/data
+      - ./mantrae:/data
     restart: unless-stopped
 ```
 


### PR DESCRIPTION
This pull request updates the volume mount paths in the Docker setup instructions in the `docs/docs/quickstart.md` file to ensure data is stored in the correct location. The changes improve consistency between the standalone Docker command and the Docker Compose configuration.

**Docker setup instructions:**

* Changed the volume mount path from `-v mantrae-data:/app/data` to `-v ./mantrae:/data` in the standalone Docker run command.
* Updated the volume mount path from `- ./mantrae:/app/data` to `- ./mantrae:/data` in the Docker Compose configuration.