### PR TITLE
Fix install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,8 +37,8 @@ main() {
    *) echo "Unsupported architecture: $arch" && exit 1 ;;
    esac
 
-   # The filename matches goreleaser binary format: binary_platform_arch
-   filename="${binary}_${platform}_${arch}"
+   # The filename matches goreleaser binary format: binary_version_platform_arch
+   filename="${binary}_${latest#v}_${platform}_${arch}"
    [ "$platform" = "windows" ] && filename="${filename}.exe"
    url="${REPO}/${latest}/${filename}"
 


### PR DESCRIPTION
Running the oneliner script on a test VM fails:

```
root@test-traefik:~# curl -fsSL https://raw.githubusercontent.com/mizuchilabs/mantrae/main/install.sh | bash
Downloading mantrae_linux_amd64 from https://github.com/mizuchilabs/mantrae/releases/download/v0.8.2/mantrae_linux_amd64
curl: (22) The requested URL returned error: 404
```

This is because goreleaser filename contains the version as well.

I have submitted this fix to correct the behavior.

Please note that current implementation use bash specific expression so therefore maybe an alternative implementation is required or the shebang must be changed for bash instead of sh.

Wdyt?

Cheers