### PR TITLE
Fix: Prevent empty default middlewares and entrypoints array initialization in Router forms

### DIFF
--- a/web/ui/src/lib/components/forms/HTTPRouterForm.svelte
+++ b/web/ui/src/lib/components/forms/HTTPRouterForm.svelte
@@ -45,14 +45,14 @@
 	});
 	$effect(() => {
 		if (epList.isSuccess && epList.data && !data.id) {
-			config.entryPoints = [epList.data.find((ep) => ep.isDefault)?.name ?? ''];
+			const defaultEp = epList.data.find((ep) => ep.isDefault);
+			config.entryPoints = defaultEp ? [defaultEp.name] : [];
 		}
 	});
 	$effect(() => {
 		if (mwList.isSuccess && mwList.data && !data.id) {
-			config.middlewares = [
-				mwList.data.find((mw) => mw.isDefault && mw.type === data.type)?.name ?? ''
-			];
+			const defaultMw = mwList.data.find((mw) => mw.isDefault && mw.type === data.type);
+			config.middlewares = defaultMw ? [defaultMw.name] : [];
 		}
 	});
 </script>

--- a/web/ui/src/lib/components/forms/TCPRouterForm.svelte
+++ b/web/ui/src/lib/components/forms/TCPRouterForm.svelte
@@ -42,14 +42,14 @@
 	});
 	$effect(() => {
 		if (epList.isSuccess && epList.data && !data.id) {
-			config.entryPoints = [epList.data.find((ep) => ep.isDefault)?.name ?? ''];
+			const defaultEp = epList.data.find((ep) => ep.isDefault);
+			config.entryPoints = defaultEp ? [defaultEp.name] : [];
 		}
 	});
 	$effect(() => {
 		if (mwList.isSuccess && mwList.data && !data.id) {
-			config.middlewares = [
-				mwList.data.find((mw) => mw.isDefault && mw.type === data.type)?.name ?? ''
-			];
+			const defaultMw = mwList.data.find((mw) => mw.isDefault && mw.type === data.type);
+			config.middlewares = defaultMw ? [defaultMw.name] : [];
 		}
 	});
 </script>

--- a/web/ui/src/lib/components/forms/UDPRouterForm.svelte
+++ b/web/ui/src/lib/components/forms/UDPRouterForm.svelte
@@ -20,7 +20,8 @@
 	});
 	$effect(() => {
 		if (epList.isSuccess && epList.data && !data.id) {
-			config.entryPoints = [epList.data.find((ep) => ep.isDefault)?.name ?? ''];
+			const defaultEp = epList.data.find((ep) => ep.isDefault);
+			config.entryPoints = defaultEp ? [defaultEp.name] : [];
 		}
 	});
 </script>


### PR DESCRIPTION
# Fix: Prevent empty default middlewares and entrypoints array initialization in Router forms

## Description
This PR resolves an issue during router creation where missing default entries inadvertently injected an empty string (`['']`) into the middlewares and entrypoints configuration arrays, instead of initializing them as truly empty (`[]`). 

## Impact
Beyond UI side-effects (empty ghost chips appearing in Select inputs), this bug generated invalid Traefik configurations. Saving a router with this implicit empty string caused Traefik to look up a malformed middleware reference (e.g., trying to parse `@http` without a proper prefix or name), breaking the routing for that specific service.

## Changes Made
- Updated the reactive `$effect` blocks handling default population in:
  - HTTPRouterForm.svelte
  - TCPRouterForm.svelte
  - UDPRouterForm.svelte
- Added explicit checks to ensure `mwList.data.find()` and `epList.data.find()` actually return an object before attempting to extract its name. If undefined, it strictly falls back to `[]` instead of defaulting to `''`.